### PR TITLE
KAN-100/prevent_users_editing_others_experiences

### DIFF
--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -57,7 +57,7 @@ export default function NavBar() {
             </Link>
           </div>
           <div>
-            <Link to="/login" state={{ from: location.pathname }}>
+            <Link to="/login">
               <span>Login</span>
             </Link>
             <Link to="/createAccount">

--- a/frontend/src/components/TripExperienceTile.jsx
+++ b/frontend/src/components/TripExperienceTile.jsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import RemoveTripExperienceButton from '../components/RemoveTripExperienceButton';
 import '../css/ExperienceTile.css';
 
-export default function TripExperienceTile ({ experience, tripId, onRemove }){    
+export default function TripExperienceTile ({ experience, tripId, onRemove, showDelete=true}){    
     const navigate = useNavigate();
 
     // Redirects to individual experience
@@ -36,7 +36,7 @@ export default function TripExperienceTile ({ experience, tripId, onRemove }){
 
             <div className='button-edit-container'>
                 <div className='delete'>
-                    <RemoveTripExperienceButton tripId={tripId} experienceId={experience.experience_id} onExperienceRemoved={onRemove}/>
+                    {showDelete && <RemoveTripExperienceButton tripId={tripId} experienceId={experience.experience_id} onExperienceRemoved={onRemove}/>}
                 </div>
             </div>
         </div>

--- a/frontend/src/pages/FeedPage.jsx
+++ b/frontend/src/pages/FeedPage.jsx
@@ -70,7 +70,7 @@ export default function FeedPage({ userId }) {
         {experiences.length > 0 ? (
           experiences.map((experience) => (
             <div key={experience.experience_id}>
-              <TripExperienceTile experience={experience} />
+              <TripExperienceTile experience={experience} showDelete={false}/>
               <SaveTripButton
                 tripId={experience.experience_id}
                 tripName={experience.trip_name || experience.title}

--- a/frontend/src/pages/IndividualExperience.jsx
+++ b/frontend/src/pages/IndividualExperience.jsx
@@ -169,8 +169,10 @@ export default function IndividualExperience() {
               </div>
           </div>
 
-            <EditExperienceButton experience={experience} />
-            <DeleteExperienceButton experience={experience} />
+            {experience.user_id === JSON.parse(atob(localStorage.getItem("token").split(".")[1]))
+              .sub && <EditExperienceButton experience={experience} />}
+            {experience.user_id === JSON.parse(atob(localStorage.getItem("token").split(".")[1]))
+              .sub && <DeleteExperienceButton experience={experience} />}
             {/* TODO: Add ExperinceTrip button  */}
             <ButtonLink varient="button-back" buttonName="Back" routeTo="/myExperiences" />
             

--- a/frontend/src/pages/IndividualExperience.jsx
+++ b/frontend/src/pages/IndividualExperience.jsx
@@ -46,6 +46,10 @@ export default function IndividualExperience() {
         fetchKeywords();
 
         const fetchUserRating = async () => {
+          if (!localStorage.getItem("token")) {
+            return;
+          }
+
           try {
             const response = await fetch(`${import.meta.env.VITE_API_URL}/experience_user_rating/${experience.experience_id}`, {
               headers: {
@@ -84,6 +88,10 @@ export default function IndividualExperience() {
     }, [experience.experience_id]);
 
     async function handleRatingChange(e) {
+      if (!localStorage.getItem("token")) {
+        return;
+      }
+
       setUserRating(e.target.value);
 
       await fetch(`${import.meta.env.VITE_API_URL}/rate_experience`, {
@@ -126,15 +134,19 @@ export default function IndividualExperience() {
                   <img src={photoURL} alt="Experience Image" />
                   <div className="rating-container">
                     <h1>Rating: {rating}</h1>
-                    <span>Your rating: </span>
-                    <select name="rating" value={userRating} onChange={handleRatingChange}>
-                      <option value="">Select Rating</option>
-                      <option value="1">1 Star</option>
-                      <option value="2">2 Stars</option>
-                      <option value="3">3 Stars</option>
-                      <option value="4">4 Stars</option>
-                      <option value="5">5 Stars</option>
-                    </select>
+                    {localStorage.getItem("token") &&
+                    <div>
+                      <span>Your rating: </span>
+                      <select name="rating" value={userRating} onChange={handleRatingChange}>
+                        <option value="">Select Rating</option>
+                        <option value="1">1 Star</option>
+                        <option value="2">2 Stars</option>
+                        <option value="3">3 Stars</option>
+                        <option value="4">4 Stars</option>
+                        <option value="5">5 Stars</option>
+                      </select>
+                    </div>
+                    }
                   </div>
                 </div>
                 {/* right side  */}
@@ -169,9 +181,9 @@ export default function IndividualExperience() {
               </div>
           </div>
 
-            {experience.user_id === JSON.parse(atob(localStorage.getItem("token").split(".")[1]))
+            {localStorage.getItem("token") && experience.user_id === JSON.parse(atob(localStorage.getItem("token").split(".")[1]))
               .sub && <EditExperienceButton experience={experience} />}
-            {experience.user_id === JSON.parse(atob(localStorage.getItem("token").split(".")[1]))
+            {localStorage.getItem("token") && experience.user_id === JSON.parse(atob(localStorage.getItem("token").split(".")[1]))
               .sub && <DeleteExperienceButton experience={experience} />}
             {/* TODO: Add ExperinceTrip button  */}
             <ButtonLink varient="button-back" buttonName="Back" routeTo="/myExperiences" />

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,15 +1,13 @@
 import NavBar from "../components/NavBar";
 import "../css/CreateAccountLogin.css";
 import { useState } from "react";
-import { Link, useNavigate, useLocation } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 export default function Login() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [errors, setErrors] = useState([]);
   const navigate = useNavigate();
-  const location = useLocation();
-  const { from } = location.state || { from: "/" };
 
   async function submitLogin(e) {
     e.preventDefault();
@@ -45,7 +43,7 @@ export default function Login() {
     if (res.status === 200) {
       const token = await res.json();
       localStorage.setItem("token", "Bearer " + token.access_token);
-      navigate(from);
+      navigate("/");
     } else {
       const error = await res.json();
       setErrors(error.errors);


### PR DESCRIPTION
The backend functionality already restricts users from editing or deleting experiences that aren't theirs, however, I implemented some frontend functionality to hide these options on experiences that don't belong to the user or if a user isn't signed in.

On the feed page, I've hidden all of the trash can icons. This trash can icon is associated with removing an experience from a particular trip, however, this wouldn't make much sense being shown on the feed page as no particular trip would be referenced.

On the individual experience page, I've implemented logic that hides the edit and delete button if the experience doesn't belong to the current signed in user or if the user isn't signed in. I've also implemented logic that hides the "Your Rating" field if the user isn't signed in.

As side note, I've changed the login page to redirect back to the home page upon successful sign in instead of the previous page that the user was on. I noticed that if a user navigated to the login page from an individual experience page, the redirect would break when trying to go back to that experience page since the individual experience page wouldn't be passed the experience info as a prop in that scenario.